### PR TITLE
Consolidated yearly invoice #1783 

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "scripts": {
     "start": "NODE_ENV=production node dist/server",
-    "dev": "nodemon --exec babel-node -- src/server/index.js",
+    "dev": "nodemon --inspect --exec babel-node -- src/server/index.js",
     "build": "npm run build:clean && npm run build:server && npm run build:next",
     "build:clean": "rm -rf dist src/.next",
     "build:server": "babel --copy-files ./src --out-dir ./dist --ignore src/templates/widget.js,src/**/__tests__/*,src/.next/*",

--- a/src/server/lib/graphql.js
+++ b/src/server/lib/graphql.js
@@ -14,6 +14,8 @@ const getClient = accessToken => {
 
 const invoiceFields = `
   slug
+  dateFrom
+  dateTo
   totalAmount
   currency
   year
@@ -72,6 +74,18 @@ const invoiceFields = `
   }
 `;
 
+export async function fetchInvoiceByDateRange(invoiceInputType, accessToken) {
+  const query = `
+  query InvoiceByDateRange($invoiceInputType: InvoiceInputType!) {
+    InvoiceByDateRange(invoiceInputType:$invoiceInputType) {
+      ${invoiceFields}
+    }
+  }
+  `;
+  const client = getClient(accessToken);
+  const result = await client.request(query, { invoiceInputType });
+  return result.InvoiceByDateRange;
+}
 export async function fetchInvoice(invoiceSlug, accessToken) {
   const query = `
   query Invoice($invoiceSlug: String!) {

--- a/src/server/routes.js
+++ b/src/server/routes.js
@@ -56,7 +56,7 @@ export default (server, app) => {
   });
 
   /**
-   * Endpoint to download invoice in HTML, PDF or JSON
+   * Deprecated Endpoint to download invoice in HTML, PDF or JSON
    */
   server.get(
     '/collectives/:collectiveSlug/:invoiceSlug.:format(html|pdf|json)',
@@ -65,6 +65,18 @@ export default (server, app) => {
       next();
     },
     controllers.transactions.invoice,
+  );
+
+  /**
+   * Endpoint to download invoice in HTML, PDF or JSON
+   */
+  server.get(
+    '/collectives/:fromCollectiveSlug/:toCollectiveSlug/:isoStartDate/:isoEndDate.:format(html|pdf|json)',
+    (req, res, next) => {
+      req.app = app;
+      next();
+    },
+    controllers.transactions.invoiceByDateRange,
   );
 
   /**

--- a/src/server/routes.js
+++ b/src/server/routes.js
@@ -43,6 +43,12 @@ export default (server, app) => {
           <a href="/__test__/transactions-with-tax.pdf">pdf</a>
         )
       </li>
+      <li>
+        With date range (
+          <a href="/__test__/transactions-with-date-range.html">html</a>,
+          <a href="/__test__/transactions-with-date-range.pdf">pdf</a>
+        )
+      </li>
     </ul>
     `);
   });

--- a/test/__fixtures__/invoices/organization-gift-cards-monthly.json
+++ b/test/__fixtures__/invoices/organization-gift-cards-monthly.json
@@ -1,5 +1,6 @@
 {
-  "slug": "201901.opensourcecollective.amazing-organization",
+  "dateFrom": "2018-12-31T11:00:00.000Z",
+  "dateTo": "2019-12-31T11:00:00.000Z",
   "totalAmount": 85800,
   "currency": "USD",
   "year": 2019,

--- a/test/__fixtures__/invoices/organization-gift-cards-yearly.json
+++ b/test/__fixtures__/invoices/organization-gift-cards-yearly.json
@@ -1,0 +1,1236 @@
+{
+  "dateFrom": "2018-12-31T11:00:00.000Z",
+  "dateTo": "2019-01-31T11:00:00.000Z",
+  "totalAmount": 85800,
+  "currency": "USD",
+  "year": 2019,
+  "month": 1,
+  "day": null,
+  "host": {
+    "id": 11004,
+    "slug": "opensourcecollective",
+    "name": "Open Source Collective 501c6 (Non Profit)",
+    "image": "https://opencollective-production.s3-us-west-1.amazonaws.com/5f4a3920-11b6-11e8-b28d-b359f3c5ca14.png",
+    "website": "https://opencollective.com/opensource",
+    "settings": {
+      "editor": "html",
+      "apply": true,
+      "invoiceTitle": "Invoice"
+    },
+    "type": "ORGANIZATION",
+    "location": {
+      "name": null,
+      "address": "EIN 82-2037583 \n340 S LEMON AVE #3717\nWalnut, CA 91789\nUSA"
+    },
+    "countryISO": null
+  },
+  "fromCollective": {
+    "id": 666,
+    "slug": "amazing-organization",
+    "name": "Amazing Organization",
+    "currency": "USD",
+    "location": {
+      "name": null,
+      "address": null
+    },
+    "countryISO": null
+  },
+  "transactions": [
+    {
+      "id": 151061,
+      "createdAt": "Tue Jan 01 2019 05:22:08 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to Babel (Backers)",
+      "amount": 2500,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 2147,
+      "fromCollective": {
+        "id": 23558,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 580,
+        "slug": "babel",
+        "name": "Babel"
+      }
+    },
+    {
+      "id": 151098,
+      "createdAt": "Tue Jan 01 2019 05:22:22 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to Aurelia (Wood)",
+      "amount": 500,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 405,
+      "fromCollective": {
+        "id": 25346,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 10985,
+        "slug": "aureliaz",
+        "name": "Aureliaz"
+      }
+    },
+    {
+      "id": 151116,
+      "createdAt": "Tue Jan 01 2019 05:22:28 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to Babel (Backers)",
+      "amount": 1000,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 841,
+      "fromCollective": {
+        "id": 24515,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 580,
+        "slug": "babel",
+        "name": "Babel"
+      }
+    },
+    {
+      "id": 151248,
+      "createdAt": "Tue Jan 01 2019 05:23:08 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to Beaker Browser (Backers)",
+      "amount": 500,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 405,
+      "fromCollective": {
+        "id": 25066,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 788,
+        "slug": "beaker",
+        "name": "Beaker Browser"
+      }
+    },
+    {
+      "id": 151309,
+      "createdAt": "Tue Jan 01 2019 05:23:26 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to Babel (Backers)",
+      "amount": 200,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 144,
+      "fromCollective": {
+        "id": 25075,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 580,
+        "slug": "babel",
+        "name": "Babel"
+      }
+    },
+    {
+      "id": 151559,
+      "createdAt": "Tue Jan 01 2019 05:24:37 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to Babel (Backers)",
+      "amount": 200,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 144,
+      "fromCollective": {
+        "id": 23054,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 580,
+        "slug": "babel",
+        "name": "Babel"
+      }
+    },
+    {
+      "id": 151572,
+      "createdAt": "Tue Jan 01 2019 05:24:42 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to react-native-camera (Backers)",
+      "amount": 200,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 144,
+      "fromCollective": {
+        "id": 25712,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 686,
+        "slug": "react-native-camera",
+        "name": "react-native-camera"
+      }
+    },
+    {
+      "id": 151648,
+      "createdAt": "Tue Jan 01 2019 05:25:03 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to Babel (Backers)",
+      "amount": 1000,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 841,
+      "fromCollective": {
+        "id": 23333,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 580,
+        "slug": "babel",
+        "name": "Babel"
+      }
+    },
+    {
+      "id": 151647,
+      "createdAt": "Tue Jan 01 2019 05:25:03 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to curl (backer)",
+      "amount": 500,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 405,
+      "fromCollective": {
+        "id": 22530,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 14622,
+        "slug": "curl",
+        "name": "curl"
+      }
+    },
+    {
+      "id": 151650,
+      "createdAt": "Tue Jan 01 2019 05:25:03 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to Tessel (Backers)",
+      "amount": 1000,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 841,
+      "fromCollective": {
+        "id": 22932,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 150,
+        "slug": "tessel",
+        "name": "Tessel"
+      }
+    },
+    {
+      "id": 151657,
+      "createdAt": "Tue Jan 01 2019 05:25:04 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to curl (backer)",
+      "amount": 500,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 405,
+      "fromCollective": {
+        "id": 22678,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 14622,
+        "slug": "curl",
+        "name": "curl"
+      }
+    },
+    {
+      "id": 151664,
+      "createdAt": "Tue Jan 01 2019 05:25:10 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to nock (Backer)",
+      "amount": 100,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 57,
+      "fromCollective": {
+        "id": 23147,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 15501,
+        "slug": "nock",
+        "name": "nock"
+      }
+    },
+    {
+      "id": 151669,
+      "createdAt": "Tue Jan 01 2019 05:25:10 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to pug (Backers)",
+      "amount": 200,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 144,
+      "fromCollective": {
+        "id": 23147,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 454,
+        "slug": "pug",
+        "name": "pug"
+      }
+    },
+    {
+      "id": 151675,
+      "createdAt": "Tue Jan 01 2019 05:25:10 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to Babel (Backers)",
+      "amount": 200,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 144,
+      "fromCollective": {
+        "id": 22607,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 580,
+        "slug": "babel",
+        "name": "Babel"
+      }
+    },
+    {
+      "id": 151676,
+      "createdAt": "Tue Jan 01 2019 05:25:10 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to Mongoose.js (backer)",
+      "amount": 200,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 144,
+      "fromCollective": {
+        "id": 23147,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 11885,
+        "slug": "mongoose",
+        "name": "Mongoose.js"
+      }
+    },
+    {
+      "id": 151668,
+      "createdAt": "Tue Jan 01 2019 05:25:10 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to MochaJS (Backers)",
+      "amount": 200,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 144,
+      "fromCollective": {
+        "id": 23147,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 58,
+        "slug": "mochajs",
+        "name": "MochaJS"
+      }
+    },
+    {
+      "id": 151674,
+      "createdAt": "Tue Jan 01 2019 05:25:10 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to vue (Backers)",
+      "amount": 2500,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 2147,
+      "fromCollective": {
+        "id": 22510,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 903,
+        "slug": "vuejs",
+        "name": "vue"
+      }
+    },
+    {
+      "id": 151684,
+      "createdAt": "Tue Jan 01 2019 05:25:15 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to Babel (Backers)",
+      "amount": 200,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 144,
+      "fromCollective": {
+        "id": 23147,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 580,
+        "slug": "babel",
+        "name": "Babel"
+      }
+    },
+    {
+      "id": 151690,
+      "createdAt": "Tue Jan 01 2019 05:25:16 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to curl (backer)",
+      "amount": 500,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 405,
+      "fromCollective": {
+        "id": 23241,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 14622,
+        "slug": "curl",
+        "name": "curl"
+      }
+    },
+    {
+      "id": 151699,
+      "createdAt": "Tue Jan 01 2019 05:25:17 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to MochaJS (Backers)",
+      "amount": 200,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 144,
+      "fromCollective": {
+        "id": 23147,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 58,
+        "slug": "mochajs",
+        "name": "MochaJS"
+      }
+    },
+    {
+      "id": 151702,
+      "createdAt": "Tue Jan 01 2019 05:25:21 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to Parcel (Backer)",
+      "amount": 200,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 144,
+      "fromCollective": {
+        "id": 23054,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 11020,
+        "slug": "parcel",
+        "name": "Parcel"
+      }
+    },
+    {
+      "id": 151769,
+      "createdAt": "Tue Jan 01 2019 05:25:40 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to webpack (Backer)",
+      "amount": 1000,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 841,
+      "fromCollective": {
+        "id": 23766,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 302,
+        "slug": "webpack",
+        "name": "webpack"
+      }
+    },
+    {
+      "id": 151768,
+      "createdAt": "Tue Jan 01 2019 05:25:40 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to Babel (Backers)",
+      "amount": 1000,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 841,
+      "fromCollective": {
+        "id": 23766,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 580,
+        "slug": "babel",
+        "name": "Babel"
+      }
+    },
+    {
+      "id": 151801,
+      "createdAt": "Tue Jan 01 2019 05:25:52 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to Babel (Backers)",
+      "amount": 200,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 144,
+      "fromCollective": {
+        "id": 23704,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 580,
+        "slug": "babel",
+        "name": "Babel"
+      }
+    },
+    {
+      "id": 151833,
+      "createdAt": "Tue Jan 01 2019 05:26:07 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to celery (backer)",
+      "amount": 500,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 405,
+      "fromCollective": {
+        "id": 25193,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 13893,
+        "slug": "celery",
+        "name": "celery"
+      }
+    },
+    {
+      "id": 151912,
+      "createdAt": "Tue Jan 01 2019 05:26:35 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to webpack (Backer)",
+      "amount": 500,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 405,
+      "fromCollective": {
+        "id": 25980,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 302,
+        "slug": "webpack",
+        "name": "webpack"
+      }
+    },
+    {
+      "id": 151916,
+      "createdAt": "Tue Jan 01 2019 05:26:40 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to vue (Backers)",
+      "amount": 200,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 144,
+      "fromCollective": {
+        "id": 25736,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 903,
+        "slug": "vuejs",
+        "name": "vue"
+      }
+    },
+    {
+      "id": 151977,
+      "createdAt": "Tue Jan 01 2019 05:27:00 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to vue (Backers)",
+      "amount": 200,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 144,
+      "fromCollective": {
+        "id": 26153,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 903,
+        "slug": "vuejs",
+        "name": "vue"
+      }
+    },
+    {
+      "id": 152042,
+      "createdAt": "Tue Jan 01 2019 05:27:23 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to Babel (Backers)",
+      "amount": 800,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 667,
+      "fromCollective": {
+        "id": 26365,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 580,
+        "slug": "babel",
+        "name": "Babel"
+      }
+    },
+    {
+      "id": 152068,
+      "createdAt": "Tue Jan 01 2019 05:27:33 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to Babel (Backers)",
+      "amount": 1000,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 841,
+      "fromCollective": {
+        "id": 26426,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 580,
+        "slug": "babel",
+        "name": "Babel"
+      }
+    },
+    {
+      "id": 152070,
+      "createdAt": "Tue Jan 01 2019 05:27:33 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to styled-components (Backer)",
+      "amount": 500,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 405,
+      "fromCollective": {
+        "id": 26400,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 12353,
+        "slug": "styled-components",
+        "name": "styled-components"
+      }
+    },
+    {
+      "id": 152076,
+      "createdAt": "Tue Jan 01 2019 05:27:33 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to Babel (Backers)",
+      "amount": 2500,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 2147,
+      "fromCollective": {
+        "id": 26400,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 580,
+        "slug": "babel",
+        "name": "Babel"
+      }
+    },
+    {
+      "id": 152194,
+      "createdAt": "Tue Jan 01 2019 05:28:13 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to Nuxt.js (Backers)",
+      "amount": 2500,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 2147,
+      "fromCollective": {
+        "id": 26382,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 653,
+        "slug": "nuxtjs",
+        "name": "Nuxt.js"
+      }
+    },
+    {
+      "id": 152197,
+      "createdAt": "Tue Jan 01 2019 05:28:13 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to nodemon (backer)",
+      "amount": 5000,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 4325,
+      "fromCollective": {
+        "id": 26978,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 10352,
+        "slug": "nodemon",
+        "name": "nodemon"
+      }
+    },
+    {
+      "id": 152198,
+      "createdAt": "Tue Jan 01 2019 05:28:13 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to TypeORM (Love)",
+      "amount": 2000,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 1712,
+      "fromCollective": {
+        "id": 26382,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 938,
+        "slug": "typeorm",
+        "name": "TypeORM"
+      }
+    },
+    {
+      "id": 152262,
+      "createdAt": "Tue Jan 01 2019 05:28:31 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to vue (Backers)",
+      "amount": 500,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 405,
+      "fromCollective": {
+        "id": 27122,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 903,
+        "slug": "vuejs",
+        "name": "vue"
+      }
+    },
+    {
+      "id": 152264,
+      "createdAt": "Tue Jan 01 2019 05:28:31 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to Qubes OS (Backers)",
+      "amount": 2000,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 1712,
+      "fromCollective": {
+        "id": 27069,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 329,
+        "slug": "qubes-os",
+        "name": "Qubes OS"
+      }
+    },
+    {
+      "id": 152320,
+      "createdAt": "Tue Jan 01 2019 18:07:55 GMT+0000 (Coordinated Universal Time)",
+      "description": "Donation to JHipster",
+      "amount": 10000,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 8680,
+      "fromCollective": {
+        "id": 27204,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 10350,
+        "slug": "generator-jhipster",
+        "name": "JHipster"
+      }
+    },
+    {
+      "id": 152328,
+      "createdAt": "Tue Jan 01 2019 20:13:59 GMT+0000 (Coordinated Universal Time)",
+      "description": "Donation to brain.js",
+      "amount": 10000,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 8680,
+      "fromCollective": {
+        "id": 27109,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 17695,
+        "slug": "brainjs",
+        "name": "brain.js"
+      }
+    },
+    {
+      "id": 152336,
+      "createdAt": "Tue Jan 01 2019 23:26:14 GMT+0000 (Coordinated Universal Time)",
+      "description": "Donation to Qubes OS",
+      "amount": 10000,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 8680,
+      "fromCollective": {
+        "id": 27215,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 329,
+        "slug": "qubes-os",
+        "name": "Qubes OS"
+      }
+    },
+    {
+      "id": 147297,
+      "createdAt": "Tue Jan 01 2019 05:00:51 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to MochaJS (Backers)",
+      "amount": 200,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 144,
+      "fromCollective": {
+        "id": 23337,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 58,
+        "slug": "mochajs",
+        "name": "MochaJS"
+      }
+    },
+    {
+      "id": 147665,
+      "createdAt": "Tue Jan 01 2019 05:03:23 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to Vapor (Backers)",
+      "amount": 500,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 405,
+      "fromCollective": {
+        "id": 22923,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 115,
+        "slug": "vapor",
+        "name": "Vapor"
+      }
+    },
+    {
+      "id": 147702,
+      "createdAt": "Tue Jan 01 2019 05:03:40 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to CIDER (Backers)",
+      "amount": 200,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 144,
+      "fromCollective": {
+        "id": 22694,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 428,
+        "slug": "cider",
+        "name": "CIDER"
+      }
+    },
+    {
+      "id": 147722,
+      "createdAt": "Tue Jan 01 2019 05:03:46 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to lumo (Backers)",
+      "amount": 200,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 144,
+      "fromCollective": {
+        "id": 22694,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 645,
+        "slug": "lumo",
+        "name": "lumo"
+      }
+    },
+    {
+      "id": 148076,
+      "createdAt": "Tue Jan 01 2019 05:05:44 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to webpack (Backer)",
+      "amount": 1000,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 841,
+      "fromCollective": {
+        "id": 22156,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 302,
+        "slug": "webpack",
+        "name": "webpack"
+      }
+    },
+    {
+      "id": 148663,
+      "createdAt": "Tue Jan 01 2019 05:08:53 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to RuboCop (Sponsors)",
+      "amount": 20000,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 17390,
+      "fromCollective": {
+        "id": 1863,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": null,
+      "collective": {
+        "id": 427,
+        "slug": "rubocop",
+        "name": "RuboCop"
+      }
+    },
+    {
+      "id": 148688,
+      "createdAt": "Tue Jan 01 2019 05:09:05 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to vue (Backers)",
+      "amount": 200,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 144,
+      "fromCollective": {
+        "id": 23054,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 903,
+        "slug": "vuejs",
+        "name": "vue"
+      }
+    },
+    {
+      "id": 148816,
+      "createdAt": "Tue Jan 01 2019 05:09:45 GMT+0000 (Coordinated Universal Time)",
+      "description": "Monthly donation to falcon (backer)",
+      "amount": 500,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 405,
+      "fromCollective": {
+        "id": 22001,
+        "slug": "anonymized",
+        "name": "Random User"
+      },
+      "usingVirtualCardFromCollective": {
+        "id": 1863,
+        "slug": "amazing-organization",
+        "name": "amazing-organization"
+      },
+      "collective": {
+        "id": 11123,
+        "slug": "falcon",
+        "name": "Falcon"
+      }
+    }
+  ]
+}

--- a/test/__fixtures__/invoices/transactions-with-date-range.json
+++ b/test/__fixtures__/invoices/transactions-with-date-range.json
@@ -1,0 +1,62 @@
+{
+  "slug": null,
+  "dateFrom": "2018-12-31T23:00:00.000Z",
+  "dateTo": "2019-12-31T23:00:00.000Z",
+  "totalAmount": 4000,
+  "currency": "USD",
+  "year": null,
+  "month": null,
+  "day": null,
+  "host": {
+    "id": 9805,
+    "slug": "opensourceorg",
+    "name": "Open Source Collective",
+    "image": "http://res.cloudinary.com/opencollective/image/upload/v1512157538/osc-transparent_phrlrh.png",
+    "website": null,
+    "settings": {},
+    "type": "ORGANIZATION",
+    "location": { "name": null, "address": "1 HackerWay, San Francisco" },
+    "countryISO": "US"
+  },
+  "fromCollective": {
+    "id": 10884,
+    "slug": "test43wow",
+    "name": "Zappa",
+    "currency": "USD",
+    "location": {
+      "name": "France",
+      "address": "75 avenue des bacs de fleurs\n83000, Toulon"
+    },
+    "countryISO": "FR"
+  },
+  "transactions": [
+    {
+      "id": 52924,
+      "createdAt": "Tue Feb 12 2019 14:35:00 GMT+0100 (GMT+01:00)",
+      "description": "Donation to APEX",
+      "amount": 2000,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 1712,
+      "taxAmount": 0,
+      "fromCollective": { "id": 10884, "slug": "test43wow", "name": "Zappa" },
+      "usingVirtualCardFromCollective": null,
+      "collective": { "id": 43, "slug": "apex", "name": "APEX" }
+    },
+    {
+      "id": 53096,
+      "createdAt": "Mon Mar 04 2019 09:23:46 GMT+0100 (GMT+01:00)",
+      "description": "Donation to APEX",
+      "amount": 2000,
+      "currency": "USD",
+      "type": "CREDIT",
+      "hostCurrency": "USD",
+      "netAmountInCollectiveCurrency": 1712,
+      "taxAmount": 0,
+      "fromCollective": { "id": 10884, "slug": "test43wow", "name": "Zappa" },
+      "usingVirtualCardFromCollective": null,
+      "collective": { "id": 43, "slug": "apex", "name": "APEX" }
+    }
+  ]
+}

--- a/test/pages/__snapshots__/invoice.test.js.snap
+++ b/test/pages/__snapshots__/invoice.test.js.snap
@@ -429,18 +429,29 @@ USA
           >
             Donation Receipt
           </h2>
-          <div
-            className="jsx-1770593735 detail"
-          >
-            <label
-              className="jsx-1770593735"
+          <div>
+            <div
+              className="detail"
             >
-              Date:
-            </label>
-             
-            <span>
-              01/31/2019
-            </span>
+              <label>
+                From:
+              </label>
+               
+              <span>
+                12/31/2018
+              </span>
+            </div>
+            <div
+              className="detail"
+            >
+              <label>
+                To:
+              </label>
+               
+              <span>
+                12/31/2019
+              </span>
+            </div>
           </div>
           <div
             className="jsx-1770593735 detail reference"
@@ -451,7 +462,7 @@ USA
               Reference:
             </label>
              
-            201901.opensourcecollective.amazing-organization
+            opensourcecollective_amazing-organization_20181231-20191231
           </div>
         </div>
       </div>
@@ -3593,11 +3604,9 @@ USA
             Donation Receipt
           </h2>
           <div
-            className="jsx-1770593735 detail"
+            className="detail"
           >
-            <label
-              className="jsx-1770593735"
-            >
+            <label>
               Date:
             </label>
              
@@ -4235,11 +4244,9 @@ USA
             Donation Receipt
           </h2>
           <div
-            className="jsx-1770593735 detail"
+            className="detail"
           >
-            <label
-              className="jsx-1770593735"
-            >
+            <label>
               Date:
             </label>
              
@@ -4497,6 +4504,3182 @@ USA
           </p>
           <p
             className="c33"
+          >
+            <span>
+              EIN 82-2037583 
+340 S LEMON AVE #3717
+Walnut
+              <br />
+            </span>
+            <span>
+              CA 91789
+USA
+              <br />
+            </span>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Yearly invoice for organization with gift cards 1`] = `
+.c1 {
+  box-sizing: border-box;
+  margin-bottom: 32px;
+}
+
+.c6 {
+  box-sizing: border-box;
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10 {
+  box-sizing: border-box;
+}
+
+.c24 {
+  box-sizing: border-box;
+  padding: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c21 {
+  box-sizing: border-box;
+  margin-top: 16px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c25 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c27 {
+  box-sizing: border-box;
+  margin-top: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c30 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c9 {
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 16px;
+  -webkit-letter-spacing: -0.2px;
+  -moz-letter-spacing: -0.2px;
+  -ms-letter-spacing: -0.2px;
+  letter-spacing: -0.2px;
+  margin: 0;
+}
+
+.c33 {
+  font-size: 12px;
+  font-weight: bold;
+  line-height: 16px;
+  -webkit-letter-spacing: -0.2px;
+  -moz-letter-spacing: -0.2px;
+  -ms-letter-spacing: -0.2px;
+  letter-spacing: -0.2px;
+  margin: 0;
+  text-align: center;
+}
+
+.c34 {
+  color: #76777A;
+  font-size: 12px;
+  line-height: 16px;
+  -webkit-letter-spacing: -0.2px;
+  -moz-letter-spacing: -0.2px;
+  -ms-letter-spacing: -0.2px;
+  letter-spacing: -0.2px;
+  margin: 0;
+  margin-top: 8px;
+  text-align: center;
+}
+
+.c26 {
+  font-size: inherit;
+  font-weight: bold;
+  line-height: inherit;
+  -webkit-letter-spacing: -0.2px;
+  -moz-letter-spacing: -0.2px;
+  -ms-letter-spacing: -0.2px;
+  letter-spacing: -0.2px;
+  margin: 0;
+}
+
+.c29 {
+  font-size: inherit;
+  line-height: inherit;
+  -webkit-letter-spacing: -0.2px;
+  -moz-letter-spacing: -0.2px;
+  -ms-letter-spacing: -0.2px;
+  letter-spacing: -0.2px;
+  margin: 0;
+}
+
+.c5 {
+  color: #141414;
+  font-size: 18px;
+  font-weight: bold;
+  line-height: 20px;
+  -webkit-letter-spacing: -1.2px;
+  -moz-letter-spacing: -1.2px;
+  -ms-letter-spacing: -1.2px;
+  letter-spacing: -1.2px;
+  margin: 0;
+}
+
+.c8 {
+  font-size: 16px;
+  font-weight: bold;
+  line-height: 18px;
+  -webkit-letter-spacing: -0.4px;
+  -moz-letter-spacing: -0.4px;
+  -ms-letter-spacing: -0.4px;
+  letter-spacing: -0.4px;
+  margin: 0;
+}
+
+.c13 {
+  padding-top: 12px;
+  padding-bottom: 12px;
+  padding-left: 16px;
+  padding-right: 16px;
+  font-size: 13px;
+  font-weight: 500;
+  border-radius: 4px 0 0 4px;
+}
+
+.c14 {
+  padding-top: 12px;
+  padding-bottom: 12px;
+  padding-left: 16px;
+  padding-right: 16px;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.c15 {
+  padding-top: 12px;
+  padding-bottom: 12px;
+  padding-left: 16px;
+  padding-right: 16px;
+  font-size: 13px;
+  font-weight: 500;
+  text-align: center;
+}
+
+.c16 {
+  padding-top: 12px;
+  padding-bottom: 12px;
+  padding-left: 16px;
+  padding-right: 16px;
+  font-size: 13px;
+  font-weight: 500;
+  text-align: right;
+  border-radius: 0 4px 4px 0;
+}
+
+.c17 {
+  padding-top: 12px;
+  padding-bottom: 12px;
+  padding-left: 16px;
+  padding-right: 16px;
+  font-size: 11px;
+}
+
+.c19 {
+  padding-top: 12px;
+  padding-bottom: 12px;
+  padding-left: 16px;
+  padding-right: 16px;
+  font-size: 11px;
+  text-align: center;
+}
+
+.c20 {
+  padding-top: 12px;
+  padding-bottom: 12px;
+  padding-left: 16px;
+  padding-right: 16px;
+  font-size: 12px;
+  text-align: right;
+}
+
+.c12 {
+  background: #ebf4ff;
+  border-radius: 4px;
+}
+
+.c23 {
+  border: 0;
+  border-top: 1px solid #C4C7CC;
+  margin: 0;
+  height: 1px;
+  border-color: #E8E9EB;
+}
+
+.c22 {
+  font-size: 12px;
+  width: 50%;
+}
+
+.c28 {
+  background: #ebf4ff;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-weight: bold;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.c31 {
+  border-color: #C4C7CC;
+  border-right: 1px solid;
+  border-color: #C4C7CC;
+  margin-right: 32px;
+  padding-right: 32px;
+}
+
+.c4 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #145ECC;
+}
+
+.c4[disabled] {
+  pointer-events: none;
+  cursor: default;
+  color: #DCDEE0;
+}
+
+.c18 {
+  box-sizing: border-box;
+  margin: 0px;
+  margin-left: 8px;
+  margin-right: 8px;
+  max-width: 100%;
+  height: auto;
+  height: 1em;
+  vertical-align: middle;
+}
+
+.c0 {
+  box-sizing: border-box;
+  padding: 64px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-height: 297mm;
+}
+
+.c3 {
+  box-sizing: border-box;
+  margin-bottom: 16px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c7 {
+  box-sizing: border-box;
+  margin-top: 80px;
+  text-align: right;
+  min-height: 100px;
+}
+
+.c11 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c32 {
+  box-sizing: border-box;
+  margin: 0px;
+  max-width: 100%;
+  height: auto;
+  max-width: 200px;
+  max-height: 100px;
+}
+
+<div
+  className="jsx-1770593735 InvoicePages amazing-organization"
+>
+  <div
+    className="jsx-1770593735 pages"
+  >
+    <div
+      className="page c0"
+    >
+      <div
+        className="header c1"
+      >
+        <div
+          className="c2"
+        >
+          <div
+            className="c3"
+          >
+            <a
+              className="c4"
+              href="https://opencollective.com/opensourcecollective"
+            >
+              <h1
+                className="-Clean-h1 c5"
+              >
+                Open Source Collective 501c6 (Non Profit)
+              </h1>
+            </a>
+            <div
+              className="c6"
+            >
+              <span>
+                EIN 82-2037583 
+340 S LEMON AVE #3717
+Walnut
+                <br />
+              </span>
+              <span>
+                CA 91789
+USA
+                <br />
+              </span>
+            </div>
+            <a
+              className="website c4"
+              href="https://opencollective.com/opensourcecollective"
+            >
+              https://opencollective.com/
+              opensourcecollective
+            </a>
+          </div>
+          <div
+            className="c7"
+          >
+            <h2
+              className="-Clean-h2 c8"
+            >
+              <span>
+                Bill to
+              </span>
+            </h2>
+            <div
+              className="c6"
+            >
+              <p
+                className="c9"
+              >
+                Amazing Organization
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          className="c10"
+        >
+          <h2
+            className="-Clean-h2 c8"
+          >
+            Donation Receipt
+          </h2>
+          <div>
+            <div
+              className="detail"
+            >
+              <label>
+                From:
+              </label>
+               
+              <span>
+                12/31/2018
+              </span>
+            </div>
+            <div
+              className="detail"
+            >
+              <label>
+                To:
+              </label>
+               
+              <span>
+                01/31/2019
+              </span>
+            </div>
+          </div>
+          <div
+            className="jsx-1770593735 detail reference"
+          >
+            <label
+              className="jsx-1770593735"
+            >
+              Reference:
+            </label>
+             
+            opensourcecollective_amazing-organization_20181231-20190131
+          </div>
+        </div>
+      </div>
+      <div
+        className="c11"
+        width={1}
+      >
+        <table
+          style={
+            Object {
+              "borderCollapse": "collapse",
+              "width": "100%",
+            }
+          }
+        >
+          <thead>
+            <tr
+              className="c12"
+            >
+              <td
+                className="c13"
+                fontSize="LeadParagraph"
+                fontWeight={500}
+              >
+                <span>
+                  Date
+                </span>
+              </td>
+              <td
+                className="c14"
+                fontSize="LeadParagraph"
+                fontWeight={500}
+              >
+                <span>
+                  Description
+                </span>
+              </td>
+              <td
+                className="c15"
+                fontSize="LeadParagraph"
+                fontWeight={500}
+              >
+                <span>
+                  Tax %
+                </span>
+              </td>
+              <td
+                className="c16"
+                fontSize="LeadParagraph"
+                fontWeight={500}
+              >
+                <span>
+                  Total
+                </span>
+              </td>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/babel"
+                    >
+                      Monthly donation to Babel (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $25.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/aureliaz"
+                    >
+                      Monthly donation to Aurelia (Wood)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $5.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/babel"
+                    >
+                      Monthly donation to Babel (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $10.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/beaker"
+                    >
+                      Monthly donation to Beaker Browser (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $5.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/babel"
+                    >
+                      Monthly donation to Babel (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $2.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/babel"
+                    >
+                      Monthly donation to Babel (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $2.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/react-native-camera"
+                    >
+                      Monthly donation to react-native-camera (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $2.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/babel"
+                    >
+                      Monthly donation to Babel (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $10.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/curl"
+                    >
+                      Monthly donation to curl (backer)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $5.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/tessel"
+                    >
+                      Monthly donation to Tessel (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $10.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/curl"
+                    >
+                      Monthly donation to curl (backer)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $5.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/nock"
+                    >
+                      Monthly donation to nock (Backer)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $1.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/pug"
+                    >
+                      Monthly donation to pug (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $2.00
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div
+      className="page c0"
+    >
+      <div
+        className="c11"
+        width={1}
+      >
+        <table
+          style={
+            Object {
+              "borderCollapse": "collapse",
+              "width": "100%",
+            }
+          }
+        >
+          <thead>
+            <tr
+              className="c12"
+            >
+              <td
+                className="c13"
+                fontSize="LeadParagraph"
+                fontWeight={500}
+              >
+                <span>
+                  Date
+                </span>
+              </td>
+              <td
+                className="c14"
+                fontSize="LeadParagraph"
+                fontWeight={500}
+              >
+                <span>
+                  Description
+                </span>
+              </td>
+              <td
+                className="c15"
+                fontSize="LeadParagraph"
+                fontWeight={500}
+              >
+                <span>
+                  Tax %
+                </span>
+              </td>
+              <td
+                className="c16"
+                fontSize="LeadParagraph"
+                fontWeight={500}
+              >
+                <span>
+                  Total
+                </span>
+              </td>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/babel"
+                    >
+                      Monthly donation to Babel (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $2.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/mongoose"
+                    >
+                      Monthly donation to Mongoose.js (backer)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $2.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/mochajs"
+                    >
+                      Monthly donation to MochaJS (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $2.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/vuejs"
+                    >
+                      Monthly donation to vue (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $25.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/babel"
+                    >
+                      Monthly donation to Babel (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $2.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/curl"
+                    >
+                      Monthly donation to curl (backer)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $5.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/mochajs"
+                    >
+                      Monthly donation to MochaJS (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $2.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/parcel"
+                    >
+                      Monthly donation to Parcel (Backer)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $2.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/webpack"
+                    >
+                      Monthly donation to webpack (Backer)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $10.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/babel"
+                    >
+                      Monthly donation to Babel (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $10.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/babel"
+                    >
+                      Monthly donation to Babel (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $2.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/celery"
+                    >
+                      Monthly donation to celery (backer)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $5.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/webpack"
+                    >
+                      Monthly donation to webpack (Backer)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $5.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/vuejs"
+                    >
+                      Monthly donation to vue (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $2.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/vuejs"
+                    >
+                      Monthly donation to vue (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $2.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/babel"
+                    >
+                      Monthly donation to Babel (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $8.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/babel"
+                    >
+                      Monthly donation to Babel (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $10.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/styled-components"
+                    >
+                      Monthly donation to styled-components (Backer)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $5.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/babel"
+                    >
+                      Monthly donation to Babel (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $25.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/nuxtjs"
+                    >
+                      Monthly donation to Nuxt.js (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $25.00
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div
+      className="page c0"
+    >
+      <div
+        className="c11"
+        width={1}
+      >
+        <table
+          style={
+            Object {
+              "borderCollapse": "collapse",
+              "width": "100%",
+            }
+          }
+        >
+          <thead>
+            <tr
+              className="c12"
+            >
+              <td
+                className="c13"
+                fontSize="LeadParagraph"
+                fontWeight={500}
+              >
+                <span>
+                  Date
+                </span>
+              </td>
+              <td
+                className="c14"
+                fontSize="LeadParagraph"
+                fontWeight={500}
+              >
+                <span>
+                  Description
+                </span>
+              </td>
+              <td
+                className="c15"
+                fontSize="LeadParagraph"
+                fontWeight={500}
+              >
+                <span>
+                  Tax %
+                </span>
+              </td>
+              <td
+                className="c16"
+                fontSize="LeadParagraph"
+                fontWeight={500}
+              >
+                <span>
+                  Total
+                </span>
+              </td>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/nodemon"
+                    >
+                      Monthly donation to nodemon (backer)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $50.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/typeorm"
+                    >
+                      Monthly donation to TypeORM (Love)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $20.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/vuejs"
+                    >
+                      Monthly donation to vue (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $5.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/qubes-os"
+                    >
+                      Monthly donation to Qubes OS (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $20.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/generator-jhipster"
+                    >
+                      Donation to JHipster
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $100.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/brainjs"
+                    >
+                      Donation to brain.js
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $100.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/qubes-os"
+                    >
+                      Donation to Qubes OS
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $100.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/mochajs"
+                    >
+                      Monthly donation to MochaJS (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $2.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/vapor"
+                    >
+                      Monthly donation to Vapor (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $5.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/cider"
+                    >
+                      Monthly donation to CIDER (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $2.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/lumo"
+                    >
+                      Monthly donation to lumo (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $2.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/webpack"
+                    >
+                      Monthly donation to webpack (Backer)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $10.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <a
+                  className="c4"
+                  href="https://opencollective.com/rubocop"
+                >
+                  Monthly donation to RuboCop (Sponsors)
+                </a>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $200.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/vuejs"
+                    >
+                      Monthly donation to vue (Backers)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $2.00
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <span>
+                  01/01/2019
+                </span>
+              </td>
+              <td
+                className="c17"
+                fontSize="Caption"
+              >
+                <div>
+                  <span>
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/falcon"
+                    >
+                      Monthly donation to falcon (backer)
+                    </a>
+                     by 
+                    <a
+                      className="c4"
+                      href="https://opencollective.com/anonymized"
+                    >
+                      Random User
+                    </a>
+                  </span>
+                  <img
+                    alt=" | "
+                    className="c18"
+                    height="1em"
+                    src="[IMAGE_URL]"
+                  />
+                </div>
+              </td>
+              <td
+                className="c19"
+                fontSize="Caption"
+              >
+                0
+                %
+              </td>
+              <td
+                className="c20"
+                fontSize="Paragraph"
+              >
+                $5.00
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <div
+          className="c21"
+        >
+          <div
+            className="c22"
+          >
+            <hr
+              className="c23"
+            />
+            <div
+              className="c24"
+            >
+              <div
+                className="c25"
+              >
+                <span>
+                  Subtotal
+                </span>
+                <span
+                  className="-Clean-span c26"
+                >
+                  $858.00
+                </span>
+              </div>
+              <div
+                className="c27"
+              >
+                <span>
+                  VAT
+                </span>
+                <span
+                  className="-Clean-span c26"
+                >
+                  $0.00
+                </span>
+              </div>
+            </div>
+            <div
+              className="c28"
+            >
+              <span>
+                Total
+              </span>
+              <span
+                className="-Clean-span c29"
+              >
+                $858.00
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="footer c30"
+      >
+        <div
+          className="c31"
+        >
+          <a
+            className="c4"
+            href="https://opencollective.com/opensource"
+          >
+            <img
+              className="c32"
+              src="https://opencollective.com/proxy/images?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2F5f4a3920-11b6-11e8-b28d-b359f3c5ca14.png&height=200"
+            />
+          </a>
+        </div>
+        <div
+          className="c10"
+        >
+          <p
+            className="c33"
+          >
+            Open Source Collective 501c6 (Non Profit)
+          </p>
+          <p
+            className="c34"
           >
             <span>
               EIN 82-2037583 

--- a/test/pages/invoice.test.js
+++ b/test/pages/invoice.test.js
@@ -3,7 +3,8 @@ import InvoicePage from '../../src/pages/invoice';
 
 import renderWithTheme from '../__helpers__/renderWithTheme';
 import simpleTransactionInvoice from '../__fixtures__/invoices/simple-transaction';
-import organizationWithGiftCardsInvoice from '../__fixtures__/invoices/organization-gift-cards';
+import organizationWithGiftCardsInvoiceMonthly from '../__fixtures__/invoices/organization-gift-cards-monthly';
+import organizationWithGiftCardsInvoiceYearly from '../__fixtures__/invoices/organization-gift-cards-yearly';
 import invoiceWithTaxes from '../__fixtures__/invoices/transactions-with-tax';
 
 describe('Single transaction invoice', () => {
@@ -20,7 +21,14 @@ describe('Single transaction invoice', () => {
 
 describe('Monthly invoice', () => {
   test('for organization with gift cards', () => {
-    const tree = renderWithTheme(<InvoicePage invoice={organizationWithGiftCardsInvoice} />).toJSON();
+    const tree = renderWithTheme(<InvoicePage invoice={organizationWithGiftCardsInvoiceMonthly} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});
+
+describe('Yearly invoice', () => {
+  test('for organization with gift cards', () => {
+    const tree = renderWithTheme(<InvoicePage invoice={organizationWithGiftCardsInvoiceYearly} />).toJSON();
     expect(tree).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
# [Consolidated yearly invoice](https://github.com/opencollective/opencollective/issues/1783)

This adds a new route:
```
'/collectives/:fromCollectiveSlug/:toCollectiveSlug/:isoStartDate/:isoEndDate.:format(html|pdf|json)',
```

And updates the `invoice` template to:
- render  from and to dates when applicable
- use a different invoice reference format for invoices with a date range. The new format is: `${invoice.host.slug}_${invoice.fromCollective.slug}_${startString}-${endString}`