### PR TITLE
TransactionInvoice: Remove collective from default route

### DIFF
--- a/pages/transactions/[transactionUuid]/[filename].js
+++ b/pages/transactions/[transactionUuid]/[filename].js
@@ -1,10 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import PDFLayout from '../../../../components/PDFLayout';
-import { Receipt } from '../../../../components/Receipt';
-import PageFormat from '../../../../lib/constants/page-format';
-import { fetchTransactionInvoice } from '../../../../lib/graphql/queries';
-import { getAccessTokenFromReq } from '../../../../lib/req-utils';
+import PDFLayout from '../../../components/PDFLayout';
+import { Receipt } from '../../../components/Receipt';
+import PageFormat from '../../../lib/constants/page-format';
+import { fetchTransactionInvoice } from '../../../lib/graphql/queries';
+import { getAccessTokenFromReq } from '../../../lib/req-utils';
 
 class TransactionReceipt extends React.Component {
   static async getInitialProps(ctx) {


### PR DESCRIPTION
Removes the `/:collective/transactions/:uuid/invoice.pdf` route that is not used anymore.
Restores the `/transactions/:uuid/invoice.pdf` route that was mistakenly removed in https://github.com/opencollective/opencollective-invoices/pull/267