### PR TITLE
TransactionInvoice: Add fallback message for old URL

### DIFF
--- a/pages/[collectiveSlug]/transactions/[:uuid]/[filename].js
+++ b/pages/[collectiveSlug]/transactions/[:uuid]/[filename].js
@@ -1,0 +1,30 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { H1 } from '@bit/opencollective.design-system.components.styled-text';
+import Container from '@bit/opencollective.design-system.components.styled-container';
+
+class TransactionReceipt extends React.Component {
+  static getInitialProps(ctx) {
+    return { collectiveSlug: ctx.query.collectiveSlug };
+  }
+
+  render() {
+    return (
+      <Container border="1px solid black" p={3} borderRadius={8} m={3}>
+        <H1>
+          This URL has been deprecated. Please go to{' '}
+          <a href={`https://opencollective.com/${this.props.collectiveSlug}/transactions`}>
+            https://opencollective.com/{this.props.collectiveSlug}/transactions
+          </a>{' '}
+          instead to download your receipt.
+        </H1>
+      </Container>
+    );
+  }
+}
+
+TransactionReceipt.propTypes = {
+  collectiveSlug: PropTypes.string.isRequired,
+};
+
+export default TransactionReceipt;

--- a/pages/transactions/[transactionUuid]/[filename].js
+++ b/pages/transactions/[transactionUuid]/[filename].js
@@ -10,9 +10,8 @@ class TransactionReceipt extends React.Component {
   static async getInitialProps(ctx) {
     const isServer = Boolean(ctx.req);
     if (isServer) {
-      const { collectiveSlug, transactionUuid } = ctx.query;
-      const errorMsgIfForbidden = `This endpoint requires authentication. If you ended up on this link directly, please go to https://opencollective.com/${collectiveSlug}/transactions instead to download your receipt.`;
-      const accessToken = getAccessTokenFromReq(ctx, errorMsgIfForbidden);
+      const { transactionUuid } = ctx.query;
+      const accessToken = getAccessTokenFromReq(ctx);
       const receipt = await fetchTransactionInvoice(transactionUuid, accessToken, ctx.query.app_key);
       return { receipt, pageFormat: ctx.query.pageFormat };
     }


### PR DESCRIPTION
Because if people click on a link sent in an old email, it still nice for them to have a nice message telling them what to do rather than contacting support.

![image](https://user-images.githubusercontent.com/1556356/77185240-5f6e6180-6ad1-11ea-91bb-48984e97000b.png)
