### PR TITLE
Accept requests without autorization header

### DIFF
--- a/lib/req-utils.js
+++ b/lib/req-utils.js
@@ -1,17 +1,10 @@
 import { get } from 'lodash';
 
-export const getAccessTokenFromReq = (
-  ctx,
-  errorMsg = `Not authorized to access ${ctx.req.url}. Please provide an authorization header or an app_key.`,
-) => {
+export const getAccessTokenFromReq = ctx => {
   const { req } = ctx;
   const authorizationHeader = get(req, 'headers.authorization') || get(req, 'headers.Authorization');
   if (!authorizationHeader) {
-    if (!get(req, 'query.app_key') && !get(ctx, 'query.app_key')) {
-      throw new Error(errorMsg);
-    } else {
-      return;
-    }
+    return;
   }
 
   const parts = authorizationHeader.split(' ');

--- a/pages/collectives/[fromCollectiveSlug]/[toCollectiveSlug]/[isoStartDate]/[isoEndDate].js
+++ b/pages/collectives/[fromCollectiveSlug]/[toCollectiveSlug]/[isoStartDate]/[isoEndDate].js
@@ -12,8 +12,7 @@ class TransactionReceipt extends React.Component {
     if (isServer) {
       const { fromCollectiveSlug, toCollectiveSlug: collectiveSlug, isoStartDate: dateFrom, isoEndDate } = ctx.query;
       const dateTo = isoEndDate.split('.')[0]; // isoEndDate can include file extension
-      const errorMsgIfForbidden = `This endpoint requires authentication. If you ended up on this link directly, please go to https://opencollective.com/${collectiveSlug}/transactions instead to download your receipt.`;
-      const accessToken = getAccessTokenFromReq(ctx, errorMsgIfForbidden);
+      const accessToken = getAccessTokenFromReq(ctx);
       const queryParams = { fromCollectiveSlug, collectiveSlug, dateFrom, dateTo };
       const receipt = await fetchInvoiceByDateRange(queryParams, accessToken, ctx.query.app_key);
       return { receipt, pageFormat: ctx.query.pageFormat };


### PR DESCRIPTION
Frontend sends `OPTIONS` requests without `authorization`, and we must not fail in such cases. It's API's responsibility to check for authentication.