### PR TITLE
Ignore OPTIONS requests

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -67,6 +67,13 @@ export default class Document extends NextJSDocument {
     const isServer = Boolean(req);
     const sheet = new ServerStyleSheet();
 
+    if (req?.method === 'OPTIONS') {
+      // Frontend sends an OPTIONS request to check CORS, we should just return OK when that happens
+      res.statusCode = 204;
+      res.end();
+      return;
+    }
+
     try {
       ctx.renderPage = () =>
         originalRenderPage({


### PR DESCRIPTION
Frontend sends an OPTIONS request to check CORS, but it doesn't have an `authorization` header. Also we don't want to generate the PDF two times when that happens, so we just return OK.